### PR TITLE
use vagrant helper to fetch winrm config

### DIFF
--- a/lib/vagrant-winrm-s/communicator.rb
+++ b/lib/vagrant-winrm-s/communicator.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
           @machine.config.winrm.username,
           @machine.config.winrm.password,
           transport: @machine.config.winrm.transport,
-          port: @machine.config.winrm.port,
+          port: winrm_info[:port],
           timeout_in_seconds: @machine.config.winrm.timeout,
           max_tries: @machine.config.winrm.max_tries)
       end


### PR DESCRIPTION
Use the port from the helper, not from the machine. See https://github.com/criteo/vagrant-winrm/pull/6/files for the last time you did this.
